### PR TITLE
Delete videos

### DIFF
--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,6 @@
 class Tutorial < ApplicationRecord
-  has_many :videos, -> { order(position: :ASC) }, inverse_of: :tutorial
+  has_many :videos, -> { order(position: :ASC) },
+           inverse_of: :tutorial, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -4,6 +4,32 @@ feature "An admin can delete a tutorial" do
   scenario "and it should no longer exist" do
     admin = create(:admin)
     create_list(:tutorial, 2)
+    tutorial = Tutorial.last
+    
+    video1 = Video.create!({
+      "title"=>"Prework - Environment Setup",
+      "description"=> Faker::Hipster.paragraph(2, true),
+      "video_id"=>"qMkRHW9zE1c",
+      "thumbnail"=>"https://i.ytimg.com/vi/qMkRHW9zE1c/hqdefault.jpg",
+      "position"=>1,
+      "tutorial_id"=> tutorial.id
+    })
+    video2 = Video.create!({
+      "title"=>"Prework - SSH Key Setup",
+      "description"=> Faker::Hipster.paragraph(2, true),
+      "video_id"=>"XsPVWGKK0qI",
+      "thumbnail"=>"https://i.ytimg.com/vi/XsPVWGKK0qI/hqdefault.jpg",
+      "position"=>2,
+      "tutorial_id"=> tutorial.id
+    })
+    video3 = Video.create!({
+      "title"=>"Prework - Strings",
+      "description"=> Faker::Hipster.paragraph(2, true),
+      "video_id"=>"iXLwXvev4X8",
+      "thumbnail"=>"https://i.ytimg.com/vi/iXLwXvev4X8/hqdefault.jpg",
+      "position"=>3,
+      "tutorial_id"=> tutorial.id
+    })
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
@@ -15,5 +41,15 @@ feature "An admin can delete a tutorial" do
       click_link 'Delete'
     end
     expect(page).to have_css('.admin-tutorial-card', count: 1)
+    expect(Tutorial.all).to_not include(tutorial)
+    expect(Video.all).to_not include(video1, video2, video3)
   end
 end
+
+
+# Background: Currently deleting a
+# Tutorial will leave all of the videos in the database,
+# meaning they will be referencing a tutorial that doesn't exist.
+
+# Use ActiveRecords dependent destroy
+# functionality to fix this.

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 feature "An admin can delete a tutorial" do
   scenario "and it should no longer exist" do
     admin = create(:admin)
-    create_list(:tutorial, 2)
-    tutorial = Tutorial.last
+    
+    tutorial1 = create(:tutorial)
+    tutorial2 = create(:tutorial)
     
     video1 = Video.create!({
       "title"=>"Prework - Environment Setup",
@@ -12,23 +13,25 @@ feature "An admin can delete a tutorial" do
       "video_id"=>"qMkRHW9zE1c",
       "thumbnail"=>"https://i.ytimg.com/vi/qMkRHW9zE1c/hqdefault.jpg",
       "position"=>1,
-      "tutorial_id"=> tutorial.id
+      "tutorial_id"=> tutorial1.id
     })
+
     video2 = Video.create!({
       "title"=>"Prework - SSH Key Setup",
       "description"=> Faker::Hipster.paragraph(2, true),
       "video_id"=>"XsPVWGKK0qI",
       "thumbnail"=>"https://i.ytimg.com/vi/XsPVWGKK0qI/hqdefault.jpg",
       "position"=>2,
-      "tutorial_id"=> tutorial.id
+      "tutorial_id"=> tutorial1.id
     })
+
     video3 = Video.create!({
       "title"=>"Prework - Strings",
       "description"=> Faker::Hipster.paragraph(2, true),
       "video_id"=>"iXLwXvev4X8",
       "thumbnail"=>"https://i.ytimg.com/vi/iXLwXvev4X8/hqdefault.jpg",
       "position"=>3,
-      "tutorial_id"=> tutorial.id
+      "tutorial_id"=> tutorial2.id
     })
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
@@ -41,8 +44,9 @@ feature "An admin can delete a tutorial" do
       click_link 'Delete'
     end
     expect(page).to have_css('.admin-tutorial-card', count: 1)
-    expect(Tutorial.all).to_not include(tutorial)
-    expect(Video.all).to_not include(video1, video2, video3)
+    expect(Tutorial.all).to_not include(tutorial1)
+    expect(Video.all).to_not include(video1, video2)
+    expect(Video.all).to include(video3)
   end
 end
 


### PR DESCRIPTION
Adds functionality where deleting a tutorial deletes all of it's associated videos, using ActiveRecord dependent::destroy method